### PR TITLE
Fix check for externalauth in login block

### DIFF
--- a/modules/indieweb_indieauth/indieweb_indieauth.module
+++ b/modules/indieweb_indieauth/indieweb_indieauth.module
@@ -81,15 +81,32 @@ function indieweb_indieauth_form_user_form_alter(&$form, FormStateInterface $for
  * @return bool
  */
 function indieweb_indieauth_user_authenticated_with_domain_on_edit_form() {
-  $authenticated = FALSE;
-
-  if (\Drupal::routeMatch()->getRouteName() == 'entity.user.edit_form' && ($account = \Drupal::routeMatch()->getParameter('user')) && \Drupal::currentUser()->id() == $account->id()) {
-    // Check if login is enabled and current user is authenticated with domain
-    // and has no administer users permission.
-    if (\Drupal::config('indieweb_indieauth.settings')->get('login_enable') && \Drupal::service('externalauth.authmap')->get($account->id(), 'indieweb') && !\Drupal::currentUser()->hasPermission('administer users')) {
-      $authenticated = TRUE;
-    }
+  if (\Drupal::routeMatch()->getRouteName() != 'entity.user.edit_form') {
+    return FALSE;
+  }
+  $account = \Drupal::routeMatch()->getParameter('user');
+  if (\Drupal::currentUser()->id() != $account->id()) {
+    return FALSE;
   }
 
-  return $authenticated;
+  // Check if login is enabled.
+  if (!\Drupal::config('indieweb_indieauth.settings')->get('login_enable')) {
+    return FALSE;
+  }
+
+  // If the user has the administer user permission we do not care on the edit
+  // form how they are authenticated, we should leave it alone.
+  if (\Drupal::currentUser()->hasPermission('administer users')) {
+    return FALSE;
+  }
+
+  // Check if the user was authenticated with their domain through IndieAuth.
+  $externalAuthMapId = 'externalauth.authmap';
+  if (\Drupal::hasService($externalAuthMapId)) {
+    /** @var \Drupal\externalauth\AuthmapInterface $externalAuthMap */
+    $externalAuthMap = \Drupal::service($externalAuthMapId);
+    $externalAuthMap->get($account->id(), 'indieweb');
+  }
+
+  return FALSE;
 }

--- a/modules/indieweb_indieauth/src/Form/IndieAuthLoginForm.php
+++ b/modules/indieweb_indieauth/src/Form/IndieAuthLoginForm.php
@@ -61,7 +61,7 @@ class IndieAuthLoginForm extends FormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $form = [];
 
-    if ($this->configuration()->get('login_enable') && !is_null($this->externalAuthMap)) {
+    if ($this->configuration()->get('login_enable') && !empty($this->externalAuthMap)) {
 
       if ($this->currentUser()->isAuthenticated()) {
         if ($this->externalAuthMap->get($this->currentUser()->id(), 'indieweb')) {

--- a/modules/indieweb_indieauth/src/Form/IndieAuthLoginForm.php
+++ b/modules/indieweb_indieauth/src/Form/IndieAuthLoginForm.php
@@ -3,6 +3,7 @@
 namespace Drupal\indieweb_indieauth\Form;
 
 use Drupal\Component\Utility\UrlHelper;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;
@@ -39,6 +40,16 @@ class IndieAuthLoginForm extends FormBase {
   }
 
   /**
+   * Get the configuration for the indieauth module.
+   *
+   * @return \Drupal\Core\Config\ImmutableConfig
+   *   The module's configuration.
+   */
+  protected function configuration() {
+    return $this->configFactory()->get('indieweb_indieauth.settings');
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function getFormId() {
@@ -51,7 +62,7 @@ class IndieAuthLoginForm extends FormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $form = [];
 
-    if (\Drupal::config('indieweb_indieauth.settings')->get('login_enable') && !is_null($this->externalAuthMap)) {
+    if ($this->configuration()->get('login_enable') && !is_null($this->externalAuthMap)) {
 
       if ($this->currentUser()->isAuthenticated()) {
         if ($this->externalAuthMap->get($this->currentUser()->id(), 'indieweb')) {
@@ -147,6 +158,8 @@ class IndieAuthLoginForm extends FormBase {
       $externalAuthMap = $container->get($authMapId);
       $form->setExternalAuthMap($externalAuthMap);
     }
+
+    $form->setConfigFactory($container->get('config.factory'));
 
     return $form;
   }

--- a/modules/indieweb_indieauth/src/Form/IndieAuthLoginForm.php
+++ b/modules/indieweb_indieauth/src/Form/IndieAuthLoginForm.php
@@ -139,9 +139,15 @@ class IndieAuthLoginForm extends FormBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
+    /** @var \Drupal\indieweb_indieauth\Form\IndieAuthLoginForm $form */
     $form = parent::create($container);
 
-    $container->get('externalauth.authmap', ContainerInterface::NULL_ON_INVALID_REFERENCE);
+    $authMapId = 'externalauth.authmap';
+    if ($container->has($authMapId)) {
+      $externalAuthMap = $container->get($authMapId);
+      $form->setExternalAuthMap($externalAuthMap);
+    }
+
     return $form;
   }
 

--- a/modules/indieweb_indieauth/src/Form/IndieAuthLoginForm.php
+++ b/modules/indieweb_indieauth/src/Form/IndieAuthLoginForm.php
@@ -3,7 +3,6 @@
 namespace Drupal\indieweb_indieauth\Form;
 
 use Drupal\Component\Utility\UrlHelper;
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;

--- a/modules/indieweb_indieauth/src/Form/IndieAuthLoginForm.php
+++ b/modules/indieweb_indieauth/src/Form/IndieAuthLoginForm.php
@@ -54,9 +54,7 @@ class IndieAuthLoginForm extends FormBase {
     if (\Drupal::config('indieweb_indieauth.settings')->get('login_enable') && !is_null($this->externalAuthMap)) {
 
       if ($this->currentUser()->isAuthenticated()) {
-        /** @var \Drupal\externalauth\AuthmapInterface $external_auth */
-        $external_authmap = \Drupal::service('externalauth.authmap');
-        if ($external_authmap && $external_authmap->get($this->currentUser()->id(), 'indieweb')) {
+        if ($this->externalAuthMap->get($this->currentUser()->id(), 'indieweb')) {
           return [];
         }
         else {

--- a/modules/indieweb_indieauth/src/Form/IndieAuthLoginForm.php
+++ b/modules/indieweb_indieauth/src/Form/IndieAuthLoginForm.php
@@ -9,8 +9,30 @@ use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Url;
 use IndieAuth\Client;
 use p3k\HTTP;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ * Class IndieAuthLoginForm.
+ *
+ * @package Drupal\indieweb_indieauth\Form
+ */
 class IndieAuthLoginForm extends FormBase {
+
+  /**
+   * The external auth authmap service.
+   *
+   * Note: this may be NULL when the service is not available.
+   *
+   * @var \Drupal\externalauth\AuthmapInterface
+   */
+  protected $externalAuthMap;
+
+  /**
+   * @param \Drupal\externalauth\AuthmapInterface $externalAuthMap
+   */
+  public function setExternalAuthMap(AuthmapInterface $externalAuthMap) {
+    $this->externalAuthMap = $externalAuthMap;
+  }
 
   /**
    * {@inheritdoc}
@@ -109,6 +131,16 @@ class IndieAuthLoginForm extends FormBase {
     else {
       $this->messenger()->addMessage($this->t('No authorization endpoint found.'));
     }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    $form = parent::create($container);
+
+    $container->get('externalauth.authmap', ContainerInterface::NULL_ON_INVALID_REFERENCE);
+    return $form;
   }
 
 }

--- a/modules/indieweb_indieauth/src/Form/IndieAuthLoginForm.php
+++ b/modules/indieweb_indieauth/src/Form/IndieAuthLoginForm.php
@@ -7,6 +7,7 @@ use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Url;
+use Drupal\externalauth\AuthmapInterface;
 use IndieAuth\Client;
 use p3k\HTTP;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -28,7 +29,10 @@ class IndieAuthLoginForm extends FormBase {
   protected $externalAuthMap;
 
   /**
+   * Set the authmap service.
+   *
    * @param \Drupal\externalauth\AuthmapInterface $externalAuthMap
+   *   The authmap service.
    */
   public function setExternalAuthMap(AuthmapInterface $externalAuthMap) {
     $this->externalAuthMap = $externalAuthMap;
@@ -47,7 +51,7 @@ class IndieAuthLoginForm extends FormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $form = [];
 
-    if (\Drupal::config('indieweb_indieauth.settings')->get('login_enable')) {
+    if (\Drupal::config('indieweb_indieauth.settings')->get('login_enable') && !is_null($this->externalAuthMap)) {
 
       if ($this->currentUser()->isAuthenticated()) {
         /** @var \Drupal\externalauth\AuthmapInterface $external_auth */

--- a/modules/indieweb_indieauth/src/Plugin/Block/IndieAuthLoginBlock.php
+++ b/modules/indieweb_indieauth/src/Plugin/Block/IndieAuthLoginBlock.php
@@ -5,6 +5,7 @@ namespace Drupal\indieweb_indieauth\Plugin\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
@@ -18,27 +19,45 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   admin_label = @Translation("Web sign-in"),
  * )
  */
-class IndieAuthLoginBlock extends BlockBase {
+class IndieAuthLoginBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The form builder.
+   *
+   * @var \Drupal\Core\Form\FormBuilderInterface
+   */
+  protected $formBuilder;
+
+  /**
+   * Set the form builder.
+   *
+   * @param \Drupal\Core\Form\FormBuilderInterface $formBuilder
+   *   The form builder (e.g. from the container).
+   */
+  public function setFormBuilder(FormBuilderInterface $formBuilder) {
+    $this->formBuilder = $formBuilder;
+  }
 
   /**
    * {@inheritdoc}
    */
   public function build() {
-    $build = [];
-    $render_form = TRUE;
+    $build = [
+      'form' => $this->formBuilder->getForm('Drupal\indieweb_indieauth\Form\IndieAuthLoginForm'),
+    ];
 
-    if (\Drupal::currentUser()->isAuthenticated()) {
-      /** @var \Drupal\externalauth\AuthmapInterface $external_authmap */
-      $external_authmap = \Drupal::service('externalauth.authmap');
-      if ($external_authmap && $external_authmap->get(\Drupal::currentUser()->id(), 'indieweb')) {
-        $render_form = FALSE;
-      }
-    }
-
-    if ($render_form) {
-      $build['form'] = \Drupal::formBuilder()->getForm('Drupal\indieweb_indieauth\Form\IndieAuthLoginForm');
-    }
     return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    /** @var \Drupal\indieweb_indieauth\Plugin\Block\IndieAuthLoginBlock $block */
+    $block = new static($configuration, $plugin_id, $plugin_definition);
+    $block->setFormBuilder($container->get('form_builder'));
+
+    return $block;
   }
 
 }


### PR DESCRIPTION
This fixes #466. Was happy to find the config form basically did exactly what I wanted to add :)

It also adds some proper dependecy injection to the components involved and removes the logic from the block itself; it just replicated logic that was already in the form too.